### PR TITLE
3.14 3.10 3.9 within PB

### DIFF
--- a/app/src/main/java/com/example/coen390_groupproject_bearcare/TemperatureActivity.java
+++ b/app/src/main/java/com/example/coen390_groupproject_bearcare/TemperatureActivity.java
@@ -61,7 +61,6 @@ public class TemperatureActivity extends AppCompatActivity {
             Log.e(TAG, e.toString());
         }
 
-
         // on click listener for take temp button
         takeTemp.setOnClickListener(new View.OnClickListener() {
             @Override


### PR DESCRIPTION
Fixed empty list in BluetoothScanner activity when enabling bluetooth.
Fixed device not scanning when location services are turned off initially.